### PR TITLE
Added including header(cstdarg) to crfsuite_api.hpp for va_list

### DIFF
--- a/include/crfsuite_api.hpp
+++ b/include/crfsuite_api.hpp
@@ -34,6 +34,7 @@
 #include <string>
 #include <stdexcept>
 #include <vector>
+#include <cstdarg>
 
 #ifndef __CRFSUITE_H__
 


### PR DESCRIPTION
In my environment, the compilation of my C++ source code using crfsuite become error.

<pre>
/usr/local/include/crfsuite_api.hpp:291: error: ‘va_list’ has not been declared
</pre>


My environment is:
- OS
  - Scientific Linux release 6.0 (Carbon)
- Compiler
  - gcc (GCC) 4.4.4 20100726 (Red Hat 4.4.4-13)

It seems that crfsuite_api.hpp just forget to include cstdarg for va_list which is argument of Trainer::__logging_callback.
This may be the problem of compiler's version...
