### PR TITLE
Allows opening a model from memory instead of a file

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -30,8 +30,6 @@ dnl ------------------------------------------------------------------
 AM_INIT_AUTOMAKE(crfsuite, 0.12)
 AC_CONFIG_HEADERS(config.h)
 AM_MAINTAINER_MODE
-AM_C_PROTOTYPES
-
 
 dnl ------------------------------------------------------------------
 dnl Checks for program

--- a/include/crfsuite.h
+++ b/include/crfsuite.h
@@ -84,7 +84,7 @@ enum {
     /** Overflow. */
     CRFSUITEERR_OVERFLOW,
     /** Not implemented. */
-    CRFSUITEERR_NOTIMPLEMENTED,
+    CRFSUITEERR_NOTIMPLEMENTED
 };
 
 /**@}*/

--- a/include/crfsuite.h
+++ b/include/crfsuite.h
@@ -747,6 +747,20 @@ int crfsuite_create_instance(const char *iid, void **ptr);
 int crfsuite_create_instance_from_file(const char *filename, void **ptr);
 
 /**
+ * Create an instance of a model object from a pointer to memory.
+ *  @param  memory      The memory containing the contents of the saved model.
+ *                      This memory will not be copied, and must remain valid
+ *                      until the instance is destroyed.
+ *  @param  length      The length of the saved model, in bytes
+ *  @param  ptr         The pointer to \c void* that points to the
+ *                      instance of the model object if successful,
+ *                      *ptr points to \c NULL otherwise.
+ *  @return int         \c 0 if this function creates an object successfully,
+ *                      \c 1 otherwise.
+ */
+int crfsuite_create_instance_from_ptr(const void *memory, int length, void **ptr);
+
+/**
  * Create instances of tagging object from a model file.
  *  @param  filename    The filename of the model.
  *  @param  ptr_tagger  The pointer to \c void* that points to the

--- a/include/crfsuite.hpp
+++ b/include/crfsuite.hpp
@@ -261,6 +261,27 @@ Tagger::~Tagger()
     this->close();
 }
 
+bool Tagger::open(const void* memory, int length)
+{
+    int ret;
+
+    // Close the model if it is already opened.
+    this->close();
+
+    // Open the model file.
+    if ((ret = crfsuite_create_instance_from_ptr(memory, length, (void**)&model))) {
+        return false;
+    }
+
+    // Obtain the tagger interface.
+    if ((ret = model->get_tagger(model, &tagger))) {
+        throw std::runtime_error("Failed to obtain the tagger interface");
+    }
+
+    return true;
+
+}
+
 bool Tagger::open(const std::string& name)
 {
     int ret;

--- a/include/crfsuite.hpp
+++ b/include/crfsuite.hpp
@@ -570,7 +570,7 @@ std::string version()
     return CRFSUITE_VERSION;
 }
 
-};
+}
 
 #endif/*__CRFSUITE_HPP__*/
 

--- a/include/crfsuite_api.hpp
+++ b/include/crfsuite_api.hpp
@@ -327,6 +327,18 @@ public:
     bool open(const std::string& name);
 
     /**
+     * Open a model using a pointer to the contents of a saved model.
+     *  @param  memory      The memory containing the contents of the saved model.
+     *                      This memory will not be copied, and must remain valid
+     *                      until the instance is destroyed.
+     *  @param  length      The length of the saved model, in bytes
+     *  @return bool        \c true if the model file is successfully opened,
+     *                      \c false otherwise 
+     *  @throw  std::runtime_error      An internal error in the model.
+     */
+    bool open(const std::string& name);
+
+    /**
      * Close the model.
      */
     void close();

--- a/include/crfsuite_api.hpp
+++ b/include/crfsuite_api.hpp
@@ -336,7 +336,7 @@ public:
      *                      \c false otherwise 
      *  @throw  std::runtime_error      An internal error in the model.
      */
-    bool open(const std::string& name);
+    bool open(const void* memory, int length);
 
     /**
      * Close the model.
@@ -408,6 +408,6 @@ std::string version();
 
 
 
-};
+}
 
 #endif/*__CRFSUITE_API_HPP__*/

--- a/lib/crf/src/crf1d.h
+++ b/lib/crf/src/crf1d.h
@@ -334,6 +334,7 @@ int crf1dmw_close_features(crf1dmw_t* writer);
 int crf1dmw_put_feature(crf1dmw_t* writer, int fid, const crf1dm_feature_t* f);
 
 crf1dm_t* crf1dm_new(const char *filename);
+crf1dm_t* crf1dm_new_from_ptr(void* memory, int length, int freeIt);
 void crf1dm_close(crf1dm_t* model);
 int crf1dm_get_num_attrs(crf1dm_t* model);
 int crf1dm_get_num_labels(crf1dm_t* model);

--- a/lib/crf/src/crf1d_tag.c
+++ b/lib/crf/src/crf1d_tag.c
@@ -422,10 +422,9 @@ static int model_dump(crfsuite_model_t* model, FILE *fpo)
     return 0;
 }
 
-static int crf1m_model_create(const char *filename, crfsuite_model_t** ptr_model)
+static int crf1m_model_create(crf1dm_t* crf1dm, crfsuite_model_t** ptr_model)
 {
     int ret = 0;
-    crf1dm_t *crf1dm = NULL;
     crf1dt_t *crf1dt = NULL;
     crfsuite_model_t *model = NULL;
     model_internal_t *internal = NULL;
@@ -435,7 +434,6 @@ static int crf1m_model_create(const char *filename, crfsuite_model_t** ptr_model
     *ptr_model = NULL;
 
     /* Open the model file. */
-    crf1dm = crf1dm_new(filename);
     if (crf1dm == NULL) {
         ret = CRFSUITEERR_INCOMPATIBLE;
         goto error_exit;
@@ -546,5 +544,10 @@ error_exit:
 
 int crf1m_create_instance_from_file(const char *filename, void **ptr)
 {
-    return crf1m_model_create(filename, (crfsuite_model_t**)ptr);
+    return crf1m_model_create(crf1dm_new(filename), (crfsuite_model_t**)ptr);
+}
+
+int crf1m_create_instance_from_ptr(const void *memory, int length, void **ptr)
+{
+    return crf1m_model_create(crf1dm_new_from_ptr(memory, length, 0), (crfsuite_model_t**)ptr);
 }

--- a/lib/crf/src/crfsuite.c
+++ b/lib/crf/src/crfsuite.c
@@ -43,6 +43,7 @@
 int crf1de_create_instance(const char *iid, void **ptr);
 int crfsuite_dictionary_create_instance(const char *interface, void **ptr);
 int crf1m_create_instance_from_file(const char *filename, void **ptr);
+int crf1m_create_instance_from_ptr(const void *memory, int length, void **ptr);
 
 int crfsuite_create_instance(const char *iid, void **ptr)
 {
@@ -59,7 +60,11 @@ int crfsuite_create_instance_from_file(const char *filename, void **ptr)
     return ret;
 }
 
-
+int crfsuite_create_instance_from_ptr(const void* memory, int length, void **ptr)
+{
+    int ret = crf1m_create_instance_from_ptr(memory, length, ptr);
+    return ret;
+}
 
 void crfsuite_attribute_init(crfsuite_attribute_t* cont)
 {


### PR DESCRIPTION
For my application, I wish to keep the model inside of a file along with other data related to the problem. For this purpose, I have implemented crfsuite_create_instance_from_ptr() which takes a pointer to memory and its length to create the instance. That way, the CRF model does not need to be stored in its own file.

I have handled the 16-byte alignment requirement by copying the data only if it is not correctly aligned.

I have updated the C++ API and tested that it works in my own software. If you want, you may incorporate this into CRFSuite.