### PR TITLE
Optimize apply_templates

### DIFF
--- a/example/crfutils.py
+++ b/example/crfutils.py
@@ -19,13 +19,17 @@ def apply_templates(X, templates):
     @type   template:   tuple of (str, int)
     @param  template:   The feature template.
     """
+    
+    x_range = list(range(len(X)))
+    x_range_set = set(x_range)
+    
     for template in templates:
         name = '|'.join(['%s[%d]' % (f, o) for f, o in template])
-        for t in range(len(X)):
+        for t in x_range:
             values = []
             for field, offset in template:
                 p = t + offset
-                if p not in range(len(X)):
+                if p not in x_range_set:
                     values = []
                     break
                 values.append(X[p][field])


### PR DESCRIPTION
Recomputing range(len(X)) for every iteration inside the loop is not necessary, because len(X) is invariant. Furthermore, using lists for membership testing (line 28 in the old version) is O(n), while it is O(1) for sets.

Testing with a sequence of ~46k items, the new code is about 8 times faster on my machine. Diffing the output of the new version and the old version showed that the outputs are the same.