### PR TITLE
fixed Trainer error handling

### DIFF
--- a/include/crfsuite.hpp
+++ b/include/crfsuite.hpp
@@ -229,7 +229,12 @@ std::string Trainer::help(const std::string& name)
     std::string str;
     crfsuite_params_t* params = tr->params(tr);
     char *_str = NULL;
-    params->help(params, name.c_str(), NULL, &_str);
+    if (params->help(params, name.c_str(), NULL, &_str) != 0) {
+        std::stringstream ss;
+        ss << "Parameter not found: " << name;
+        params->release(params);
+        throw std::invalid_argument(ss.str());
+    }
     str = _str;
     params->free(params, _str);
     params->release(params);

--- a/include/crfsuite.hpp
+++ b/include/crfsuite.hpp
@@ -175,6 +175,18 @@ int Trainer::train(const std::string& model, int holdout)
 {
     int ret;
 
+    if (tr == NULL) {
+        std::stringstream ss;
+        ss << "The trainer is not initialized. Call Trainer::select before Trainer::train.";
+        throw std::invalid_argument(ss.str());
+    }
+
+    if (data->attrs == NULL || data->labels == NULL) {
+        std::stringstream ss;
+        ss << "The data is empty. Call Trainer::append before Trainer::train.";
+        throw std::invalid_argument(ss.str());
+    }
+
     // Run the training algorithm.
     ret = tr->train(tr, data, model.c_str(), holdout);
 


### PR DESCRIPTION
This PR fixes a case when an invalid argument is passed to `Trainer::help` and a case when `Trainer::train` is called without initializing the trainer. 