### PR TITLE
Better error handling for model files loading

### DIFF
--- a/lib/crf/src/crf1d_model.c
+++ b/lib/crf/src/crf1d_model.c
@@ -744,6 +744,7 @@ crf1dm_t* crf1dm_new(const char *filename)
 
     if (memcmp((void*)header->magic, (void*)FILEMAGIC, sizeof(header->magic))) {
         free(model->buffer_orig);
+        free(model->header);
         goto error_exit;
     }
 


### PR DESCRIPTION
There are two improvements in this PR:
- fixed memory access past allocated size;
- function returns early if the model file doesn't start with FILEMAGIC, to prevent incorrect interpretation of data.
