### PR TITLE
Implement Ruby binding

### DIFF
--- a/swig/export.i
+++ b/swig/export.i
@@ -1,7 +1,7 @@
-#if defined(SWIGPYTHON)
-%module(directors="1") crfsuite
-#else
+#if defined(SWIGPERL)
 %module(directors="1") CRFSuite
+#else
+%module(directors="1") crfsuite
 #endif
 
 %{

--- a/swig/ruby/README
+++ b/swig/ruby/README
@@ -1,0 +1,33 @@
+CRFsuite Ruby module via SWIG
+
+* HOW TO BUILD
+
+0. Build CRFsuite and install it (the library and include files are necessary)
+
+1. Generate a SWIG wrapper
+$ ./prepare.sh --swig
+
+2. Build the binding.
+$ ruby extconf.rb
+
+3. Install the binding.
+$ make install
+
+4. Run the binding.
+$ irb
+irb(main):001:0> require 'crfsuite'
+
+
+* SAMPLE PROGRAMS
+Refer to sample_train.rb and sample_test.rb
+
+
+
+* NOTES FOR INSTALLING CRFSUITE IN A NON-DEFAULT DIRECTORY
+
+If you have changed the installation directory of CRFsuite using --prefix
+option for the configure script, please specify the include and library
+directories to setup.py; for example, if you have installed CRFsuite into
+$HOME/local directory, run:
+
+$ ruby extconf.rb --with-crfsuite-include=$HOME/local/include --with-crfsuite-lib=$HOME/local/lib

--- a/swig/ruby/extconf.rb
+++ b/swig/ruby/extconf.rb
@@ -1,0 +1,4 @@
+require 'mkmf'
+$LOCAL_LIBS +=' -lcrfsuite'
+dir_config('crfsuite')
+create_makefile('crfsuite')

--- a/swig/ruby/prepare.sh
+++ b/swig/ruby/prepare.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+ln -s ../crfsuite.cpp
+ln -s ../export.i
+
+if [ "$1" = "--swig" ];
+then
+    swig -c++ -ruby -I../../include -o export_wrap.cpp export.i
+fi

--- a/swig/ruby/sample_tag.rb
+++ b/swig/ruby/sample_tag.rb
@@ -1,0 +1,60 @@
+#!/usr/bin/env ruby
+
+require 'crfsuite'
+
+def instances(fi)
+  xseq = Crfsuite::ItemSequence.new
+
+  Enumerator.new do |y|
+    fi.each do |line|
+      line.chomp!
+      if line.empty?
+        # An empty line presents an end of a sequence.
+        y << xseq
+        xseq = Crfsuite::ItemSequence.new
+        next
+      end
+
+      # Split the line with TAB characters.
+      fields = line.split("\t")
+      item = Crfsuite::Item.new
+      fields.drop(1).each do |field|
+        p = field.rindex(':')
+        if p.nil?
+          # Unweighted (weight=1) attribute.
+          item << Crfsuite::Attribute.new(field)
+        else
+          # Weighted attribute
+          item << Crfsuite::Attribute.new(field[0..p-1], float(field[p+1..-1]))
+        end
+      end
+
+      # Append the item to the item sequence.
+      xseq << item
+    end
+  end
+end
+
+if __FILE__ == $0
+  model_file = ARGV[0]
+
+  # Create a tagger object.
+  tagger = Crfsuite::Tagger.new
+
+  # Load the model to the tagger.
+  tagger.open(model_file)
+
+  instances($stdin).each do |xseq|
+    # Tag the sequence.
+    tagger.set(xseq)
+    # Obtain the label sequence predicted by the tagger.
+    yseq = tagger.viterbi()
+    # Output the probability of the predicted label sequence.
+    puts tagger.probability(yseq)
+    yseq.each_with_index do |y, t|
+      # Output the predicted labels with their marginal probabilities.
+      puts '%s:%f' % [y, tagger.marginal(y, t)]
+    end
+    puts ''
+  end
+end

--- a/swig/ruby/sample_tag.rb
+++ b/swig/ruby/sample_tag.rb
@@ -19,13 +19,13 @@ def instances(fi)
       fields = line.split("\t")
       item = Crfsuite::Item.new
       fields.drop(1).each do |field|
-        p = field.rindex(':')
-        if p.nil?
+        idx = field.rindex(':')
+        if idx.nil?
           # Unweighted (weight=1) attribute.
           item << Crfsuite::Attribute.new(field)
         else
           # Weighted attribute
-          item << Crfsuite::Attribute.new(field[0..p-1], float(field[p+1..-1]))
+          item << Crfsuite::Attribute.new(field[0..idx-1], float(field[idx+1..-1]))
         end
       end
 

--- a/swig/ruby/sample_train.rb
+++ b/swig/ruby/sample_train.rb
@@ -1,0 +1,81 @@
+#!/usr/bin/env ruby
+
+require 'crfsuite'
+
+# Inherit Crfsuite::Trainer to implement message() function, which receives
+# progress messages from a training process.
+class Trainer < Crfsuite::Trainer
+  def message(s)
+    # Simply output the progress messages to STDOUT.
+    print s
+  end
+end
+
+def instances(fi)
+  xseq = Crfsuite::ItemSequence.new
+  yseq = Crfsuite::StringList.new
+
+  Enumerator.new do |y|
+    fi.each do |line|
+      line.chomp!
+      if line.empty?
+        # An empty line presents an end of a sequence.
+        y << [xseq, yseq]
+        xseq = Crfsuite::ItemSequence.new
+        yseq = Crfsuite::StringList.new
+        next
+      end
+
+      # Split the line with TAB characters.
+      fields = line.split("\t")
+
+      # Append attributes to the item.
+      item = Crfsuite::Item.new
+      fields.drop(1).each do |field|
+        idx = field.rindex(':')
+        if idx.nil?
+          # Unweighted (weight=1) attribute.
+          item << Crfsuite::Attribute.new(field)
+        else
+          # Weighted attribute
+          item << Crfsuite::Attribute.new(field[0..idx-1], field[idx+1..-1].to_f)
+        end
+      end
+
+      # Append the item to the item sequence.
+      xseq << item
+      # Append the label to the label sequence.
+      yseq << fields[0]
+    end
+  end
+end
+
+if __FILE__ == $0
+  model_file = ARGV[0]
+
+  # This demonstrates how to obtain the version string of CRFsuite.
+  puts Crfsuite.version
+
+  # Create a Trainer object.
+  trainer = Trainer.new
+
+  # Read training instances from STDIN, and set them to trainer.
+  instances($stdin).each do |xseq, yseq|
+    trainer.append(xseq, yseq, 0)
+  end
+
+  # Use L2-regularized SGD and 1st-order dyad features.
+  trainer.select('l2sgd', 'crf1d')
+
+  # This demonstrates how to list parameters and obtain their values.
+  trainer.params.each do |name|
+    print name, ' ', trainer.get(name), ' ', trainer.help(name), "\n"
+  end
+
+  # Set the coefficient for L2 regularization to 0.1
+  trainer.set('c2', '0.1')
+
+  # Start training; the training process will invoke trainer.message()
+  # to report the progress.
+  trainer.train(model_file, -1)
+end


### PR DESCRIPTION
I have implemented Ruby binding and have confirmed that it works as expected on Mac OS X 10.10.2 with Swig 3.0.5, Debian 6.0.5 with Swig 3.0.5, and Debian 6.0.5 with Swig 2.0.4.

## Installation

```
$ cd swig/ruby
$ ./prepare.sh --swig
$ ruby extconf.rb
$ make install 
```

## Execute sample codes

```
$ cd swig/ruby
$ curl -LO http://www.cnts.ua.ac.be/conll2000/chunking/train.txt.gz
$ zcat train.txt.gz | ../../example/chunking.py > train.crfsuite.txt
$ ruby sample_train.rb CoNLL2000.model < train.crfsuite.txt
0.12.2
feature.minfreq 0.000000 The minimum frequency of features.
feature.possible_states 0 Force to generate possible state features.
feature.possible_transitions 0 Force to generate possible transition features.
c2 1.000000 Coefficient for L2 regularization.
max_iterations 1000 The maximum number of iterations (epochs) for SGD optimization.
period 10 The duration of iterations to test the stopping criterion.
delta 0.000001 The threshold for the stopping criterion; an optimization process stops when
the improvement of the log likelihood over the last ${period} iterations is no
greater than this threshold.
calibration.eta 0.100000 The initial value of learning rate (eta) used for calibration.
calibration.rate 2.000000 The rate of increase/decrease of learning rate for calibration.
calibration.samples 1000 The number of instances used for calibration.
calibration.candidates 10 The number of candidates of learning rate.
calibration.max_trials 20 The maximum number of trials of learning rates for calibration.
Feature generation
type: CRF1d
feature.minfreq: 0.000000
feature.possible_states: 0
feature.possible_transitions: 0
0....1....2....3....4....5....6....7....8....9....10
Number of features: 452755
Seconds required: 2.648

Stochastic Gradient Descent (SGD)
c2: 0.100000
max_iterations: 1000
period: 10
delta: 0.000001

Calibrating the learning rate (eta)
calibration.eta: 0.100000
calibration.rate: 2.000000
calibration.samples: 1000
calibration.candidates: 10
calibration.max_trials: 20
Initial loss: 73427.713480
Trial #1 (eta = 0.100000): 6582.519447
Trial #2 (eta = 0.200000): 6730.455920
Trial #3 (eta = 0.400000): 9512.830812
Trial #4 (eta = 0.800000): 18893.911403
Trial #5 (eta = 1.600000): 37728.232850
Trial #6 (eta = 3.200000): 80183.389088 (worse)
Trial #7 (eta = 0.050000): 7630.312307
Trial #8 (eta = 0.025000): 9621.753885
Trial #9 (eta = 0.012500): 12638.018534
Trial #10 (eta = 0.006250): 16982.966482
Trial #11 (eta = 0.003125): 23074.675027
Trial #12 (eta = 0.001563): 31343.061039
Trial #13 (eta = 0.000781): 41540.646706
Trial #14 (eta = 0.000391): 52696.836433
Trial #15 (eta = 0.000195): 61945.207748
Trial #16 (eta = 0.000098): 67498.204541
Best learning rate (eta): 0.100000
Seconds required: 2.078

***** Epoch #1 *****
Loss: 33583.103783
Feature L2-norm: 63.611729
Learning rate (eta): 0.098039
Total number of feature updates: 8936
Seconds required for this iteration: 1.046

(snip)

SGD terminated with the stopping criteria
Loss: 3523.303519
Total seconds required for training: 164.998

Storing the model
Number of active features: 452755 (452755)
Number of active attributes: 335674 (335674)
Number of active labels: 22 (22)
Writing labels
Writing attributes
Writing feature references for transitions
Writing feature references for attributes
Seconds required: 1.120

$ ruby sample_tag.rb CoNLL2000.model < train.crfsuite.txt > result
```
