### PR TITLE
Support Swig 3.0.5

### DIFF
--- a/swig/export.i
+++ b/swig/export.i
@@ -23,11 +23,12 @@
 %typemap(freearg) const std::string& ""
 #endif
 
+%feature("director") Trainer;
+%include "crfsuite_api.hpp"
+
 %template(Item) std::vector<CRFSuite::Attribute>;
 %template(ItemSequence) std::vector<CRFSuite::Item>;
 %template(StringList) std::vector<std::string>;
-
-%feature("director") Trainer;
 
 %exception {
     try {
@@ -42,6 +43,3 @@
         SWIG_exception(SWIG_RuntimeError,"Unknown exception");
     }
 }
-
-%include "crfsuite_api.hpp"
-

--- a/swig/export.i
+++ b/swig/export.i
@@ -24,11 +24,6 @@
 #endif
 
 %feature("director") Trainer;
-%include "crfsuite_api.hpp"
-
-%template(Item) std::vector<CRFSuite::Attribute>;
-%template(ItemSequence) std::vector<CRFSuite::Item>;
-%template(StringList) std::vector<std::string>;
 
 %exception {
     try {
@@ -43,3 +38,9 @@
         SWIG_exception(SWIG_RuntimeError,"Unknown exception");
     }
 }
+
+%include "crfsuite_api.hpp"
+
+%template(Item) std::vector<CRFSuite::Attribute>;
+%template(ItemSequence) std::vector<CRFSuite::Item>;
+%template(StringList) std::vector<std::string>;


### PR DESCRIPTION
This commit will fix the error like below with Swig 3.0.5 (I have confirmed on Mac OS 10.10.2 and Debian 6.0.5) mentioned in [Stackoverflow](http://stackoverflow.com/questions/22776173/swig-error-c-for-python-director-use):

```
% cd swig/python
% ./prepare.sh --swig
/usr/local/Cellar/swig/3.0.5/share/swig/3.0.5/std/std_vector.i:87: Error: Can't copy typemap (directorout) std::vector< CRFSuite::Item,std::allocator< CRFSuite::Item > > = std::vector< CRFSuite::Item,std::allocator< CRFSuite::Item > > &DIRECTOROUT
/usr/local/Cellar/swig/3.0.5/share/swig/3.0.5/std/std_vector.i:87: Error: Can't copy typemap (in) std::vector< CRFSuite::Item,std::allocator< CRFSuite::Item > > *INPUT = std::vector< CRFSuite::Item,std::allocator< CRFSuite::Item > > *INOUT
/usr/local/Cellar/swig/3.0.5/share/swig/3.0.5/std/std_vector.i:87: Error: Can't copy typemap (in) std::vector< CRFSuite::Item,std::allocator< CRFSuite::Item > > &INPUT = std::vector< CRFSuite::Item,std::allocator< CRFSuite::Item > > &INOUT
/usr/local/Cellar/swig/3.0.5/share/swig/3.0.5/std/std_vector.i:87: Error: Can't copy typemap (typecheck) std::vector< CRFSuite::Item,std::allocator< CRFSuite::Item > > *INPUT = std::vector< CRFSuite::Item,std::allocator< CRFSuite::Item > > *INOUT
/usr/local/Cellar/swig/3.0.5/share/swig/3.0.5/std/std_vector.i:87: Error: Can't copy typemap (typecheck) std::vector< CRFSuite::Item,std::allocator< CRFSuite::Item > > &INPUT = std::vector< CRFSuite::Item,std::allocator< CRFSuite::Item > > &INOUT
/usr/local/Cellar/swig/3.0.5/share/swig/3.0.5/std/std_vector.i:87: Error: Can't copy typemap (argout) std::vector< CRFSuite::Item,std::allocator< CRFSuite::Item > > *OUTPUT = std::vector< CRFSuite::Item,std::allocator< CRFSuite::Item > > *INOUT
/usr/local/Cellar/swig/3.0.5/share/swig/3.0.5/std/std_vector.i:87: Error: Can't copy typemap (argout) std::vector< CRFSuite::Item,std::allocator< CRFSuite::Item > > &OUTPUT = std::vector< CRFSuite::Item,std::allocator< CRFSuite::Item > > &INOUT
/usr/local/Cellar/swig/3.0.5/share/swig/3.0.5/std/std_vector.i:87: Error: Can't copy typemap (typecheck) std::vector< CRFSuite::Item,std::allocator< CRFSuite::Item > > *INPUT = std::vector< CRFSuite::Item,std::allocator< CRFSuite::Item > > *INOUT
/usr/local/Cellar/swig/3.0.5/share/swig/3.0.5/std/std_vector.i:87: Error: Can't copy typemap (typecheck) std::vector< CRFSuite::Item,std::allocator< CRFSuite::Item > > &INPUT = std::vector< CRFSuite::Item,std::allocator< CRFSuite::Item > > &INOUT
/usr/local/Cellar/swig/3.0.5/share/swig/3.0.5/std/std_vector.i:87: Error: Can't copy typemap (freearg) std::vector< CRFSuite::Item,std::allocator< CRFSuite::Item > > *INPUT = std::vector< CRFSuite::Item,std::allocator< CRFSuite::Item > > *INOUT
/usr/local/Cellar/swig/3.0.5/share/swig/3.0.5/std/std_vector.i:87: Error: Can't copy typemap (freearg) std::vector< CRFSuite::Item,std::allocator< CRFSuite::Item > > &INPUT = std::vector< CRFSuite::Item,std::allocator< CRFSuite::Item > > &INOUT
```

It also will fix the error like below with Swig 2.0.4 mentioned in README for Python binding:

```
export_wrap.cpp:5020: error: redefinition of ‘struct swig::traits<std::vector<CRFSuite::Attribute, std::allocator<CRFSuite::Attribute> > >’
export_wrap.cpp:4919: error: previous definition of ‘struct swig::traits<std::vector<CRFSuite::Attribute, std::allocator<CRFSuite::Attribute> > >’
```