### PR TITLE
Fix a python sample code

### DIFF
--- a/swig/python/sample_train.py
+++ b/swig/python/sample_train.py
@@ -17,24 +17,24 @@ def instances(fi):
     for line in fi:
         line = line.strip('\n')
         if not line:
-        	# An empty line presents an end of a sequence.
+            # An empty line presents an end of a sequence.
             yield xseq, yseq
             xseq = crfsuite.ItemSequence()
             yseq = crfsuite.StringList()
             continue
 
-		# Split the line with TAB characters.
+        # Split the line with TAB characters.
         fields = line.split('\t')
-    	
-    	# Append attributes to the item.
+        
+        # Append attributes to the item.
         item = crfsuite.Item()
         for field in fields[1:]:
             p = field.rfind(':')
             if p == -1:
-            	# Unweighted (weight=1) attribute.
+                # Unweighted (weight=1) attribute.
                 item.append(crfsuite.Attribute(field))
             else:
-            	# Weighted attribute
+                # Weighted attribute
                 item.append(crfsuite.Attribute(field[:p], float(field[p+1:])))
         
         # Append the item to the item sequence.
@@ -43,17 +43,17 @@ def instances(fi):
         yseq.append(fields[0])
 
 if __name__ == '__main__':
-	# This demonstrates how to obtain the version string of CRFsuite.
+    # This demonstrates how to obtain the version string of CRFsuite.
     print crfsuite.version()
 
-	# Create a Trainer object.
+    # Create a Trainer object.
     trainer = Trainer()
     
     # Read training instances from STDIN, and set them to trainer.
     for xseq, yseq in instances(sys.stdin):
         trainer.append(xseq, yseq, 0)
 
-	# Use L2-regularized SGD and 1st-order dyad features.
+    # Use L2-regularized SGD and 1st-order dyad features.
     trainer.select('l2sgd', 'crf1d')
     
     # This demonstrates how to list parameters and obtain their values.

--- a/swig/python/sample_train.py
+++ b/swig/python/sample_train.py
@@ -18,7 +18,7 @@ def instances(fi):
         line = line.strip('\n')
         if not line:
         	# An empty line presents an end of a sequence.
-            yield xseq, tuple(yseq)
+            yield xseq, yseq
             xseq = crfsuite.ItemSequence()
             yseq = crfsuite.StringList()
             continue


### PR DESCRIPTION
This pull request will fix the error like below:

```
$ python sample_train.py sample.model < input 
0.12.2
Traceback (most recent call last):
  File "sample_train.py", line 54, in <module>
    trainer.append(xseq, yseq, 0)
  File "/path/to/crfsuite/swig/python/crfsuite.py", line 130, in append
    def append(self, *args): return _crfsuite.Trainer_append(self, *args)
TypeError: in method 'Trainer_append', argument 3 of type 'CRFSuite::StringList const &'

```