### PR TITLE
Use INT_MIN instead of 0x80000000 to avoid overflow.

### DIFF
--- a/include/crfsuite.h
+++ b/include/crfsuite.h
@@ -37,6 +37,7 @@
 extern "C" {
 #endif/*__cplusplus*/
 
+#include <limits.h>
 #include <stdio.h>
 #include <stdarg.h>
 
@@ -72,7 +73,7 @@ enum {
     /** Success. */
     CRFSUITE_SUCCESS = 0,
     /** Unknown error occurred. */
-    CRFSUITEERR_UNKNOWN = 0x80000000,
+    CRFSUITEERR_UNKNOWN = INT_MIN,
     /** Insufficient memory. */
     CRFSUITEERR_OUTOFMEMORY,
     /** Unsupported operation. */


### PR DESCRIPTION
The integer literal 0x80000000 is a large unsigned int on most
platforms.  This causes warnings like the following when it is assigned
to a (signed) int:

```
In function ‘crfsuite_train_arow’:
warning: overflow in implicit constant conversion [-Woverflow]
     ret = CRFSUITEERR_OUTOFMEMORY;
```

Avoid these warnings by using INT_MIN instead.  This has the same value
on almost all platforms, so compatibility is retained.
