### PR TITLE
improving template rendering speed in `example/crfutils.py`.

### DIFF
--- a/example/crfutils.py
+++ b/example/crfutils.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 """
 A miscellaneous utility for sequential labeling.
 Copyright 2010,2011 Naoaki Okazaki.
@@ -21,17 +19,14 @@ def apply_templates(X, templates):
     @type   template:   tuple of (str, int)
     @param  template:   The feature template.
     """
-    
-    x_range = list(range(len(X)))
-    x_range_set = set(x_range)
-    
     for template in templates:
         name = '|'.join(['%s[%d]' % (f, o) for f, o in template])
-        for t in x_range:
+        X_len = len(X)
+        for t in range(X_len):
             values = []
             for field, offset in template:
                 p = t + offset
-                if p not in x_range_set:
+                if p < 0 or p >= X_len: 
                     values = []
                     break
                 values.append(X[p][field])


### PR DESCRIPTION
by replace "p not in range(len(X))" with " p < 0 or p >= len(X)",
avoid creating a list(in Python2) and iterating comparing.
as instance, for 420K lines input data, speed up from 59s to 20s.

--------------

**Attention**: it is a fix for example/crfsuites.py, which is just a utils to generate training data according to the template,  not the main program.