### PR TITLE
store the argmax score in Viterbi inference in a stack variable

### DIFF
--- a/lib/crf/src/crf1d_context.c
+++ b/lib/crf/src/crf1d_context.c
@@ -468,6 +468,7 @@ floatval_t crf1dc_viterbi(crf1d_context_t* ctx, int *labels)
     int i, j, t;
     int *back = NULL;
     floatval_t max_score, score, *cur = NULL;
+    int argmax_score;
     const floatval_t *prev = NULL, *state = NULL, *trans = NULL;
     const int T = ctx->num_items;
     const int L = ctx->num_labels;
@@ -493,7 +494,7 @@ floatval_t crf1dc_viterbi(crf1d_context_t* ctx, int *labels)
         /* Compute the score of (t, j). */
         for (j = 0;j < L;++j) {
             max_score = -FLOAT_MAX;
-
+            argmax_score = -1;
             for (i = 0;i < L;++i) {
                 /* Transit from (t-1, i) to (t, j). */
                 trans = TRANS_SCORE(ctx, i);
@@ -502,10 +503,11 @@ floatval_t crf1dc_viterbi(crf1d_context_t* ctx, int *labels)
                 /* Store this path if it has the maximum score. */
                 if (max_score < score) {
                     max_score = score;
-                    /* Backward link (#t, #j) -> (#t-1, #i). */
-                    back[j] = i;
+                    argmax_score = i;
                 }
             }
+            /* Backward link (#t, #j) -> (#t-1, #i). */
+            if (argmax_score >= 0) back[j] = argmax_score;
             /* Add the state score on (t, j). */
             cur[j] = max_score + state[j];
         }


### PR DESCRIPTION
Hey @chokkan,

Firstly, thanks for your many great contributions to open-source NLP!

In writing the CRF implementation for [libpostal](https://github.com/openvenues/libpostal), which borrows heavily from CRFsuite's (ours required the ability to handle a data set larger than memory as well as joint state+transition features, so couldn't use CRFsuite verbatim), there was one simple optimization I found useful and wanted to contribute it back to this repo.

During the quadratic section of Viterbi inference, the backpointer array is used to store the best label index i for time t-1 that would make the transition to label index j for time t most likely. The current label j is a given during the inner loop, but whenever a candidate for the previous label exceeds the current max score, we have to make a trip to the heap to store the new backpointer. This results in O(N²) array accesses worst case, whereas we could formulate it slightly differently by defining the backpointer for index j as simply the argmax of the L scores computed. This way, we can store the argmax in a much cheaper-to-access stack variable and only touch the backpointer array once after the inner loop is complete, which guarantees only O(N) array accesses in total.

Normally worrying about such minutiae in C is not warranted,  but since that is the quadratic section of the code and this is not the sort of thing the compiler can necessarily optimize out (unless maybe the pointer were declared with ```restrict```), I thought it might be worthwhile to try. In my experiments with ~20 labels, this small optimization resulted in a ~2x performance increase in Viterbi inference. YMMV but larger gains should be possible with more labels. This speeds up both runtime tagging as well as averaged perceptron training, which does not need to compute derivatives and only requires running inference over the sequence. Using this method, I was able to train a CRF with the averaged perceptron on over 1 billion sequences (international street addresses) in time roughly equivalent to a greedy averaged perceptron.

Though most people are probably using LBFGS on smaller models, hopefully the runtime performance gains are useful to folks!

Cheers,
Al