### PR TITLE
Memory leak fix

### DIFF
--- a/lib/crf/src/crf1d_model.c
+++ b/lib/crf/src/crf1d_model.c
@@ -776,7 +776,7 @@ crf1dm_t* crf1dm_new(const char *filename)
     fseek(fp, 0, SEEK_SET);
 
     buffer = buffer_orig = (uint8_t*)malloc(size + 16);
-    if (buffer_orig = NULL) {
+    if (buffer_orig == NULL) {
         goto error_exit;
     }
 


### PR DESCRIPTION
model->buffer_orig is always NULL and therefore is not properly destroyed in crf1dm_close