### PR TITLE
fix: prevent from setting property level of null ptr

### DIFF
--- a/lib/crf/src/crf1d_tag.c
+++ b/lib/crf/src/crf1d_tag.c
@@ -161,6 +161,7 @@ static crf1dt_t *crf1dt_new(crf1dm_t* crf1dm)
         } else {
             crf1dt_delete(crf1dt);
             crf1dt = NULL;
+            return crf1dt;
         }
         crf1dt->level = LEVEL_NONE;
     }


### PR DESCRIPTION
The code is pretty much self explanatory!

returning variable `crf1dt` here prevent from line `crf1dt->level = LEVEL_NONE;` to be executed on a NULL ptr...

Error will be easier to debug for everybody using your lib. I had to debug for at least an hour with `printf`'s to understand where the error came from... (I had no stack trace at all)

feel free to message me if you have any questions!

Good job for this library, it's really usefull.

François

