### PR TITLE
fix: call apple function when apple

### DIFF
--- a/lib/crf/src/vecmath.h
+++ b/lib/crf/src/vecmath.h
@@ -46,7 +46,7 @@
 #include <stdlib.h>
 static inline void *_aligned_malloc(size_t size, size_t alignment)
 {
-#if __STDC_VERSION__ >= 201112L
+#if __STDC_VERSION__ >= 201112L && !__APPLE__
     return aligned_alloc(alignment, size);
 #elif _POSIX_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600 || __APPLE__
     void *p;


### PR DESCRIPTION
this problem is also the one that made me right this [PR](https://github.com/chokkan/crfsuite/pull/114), although both PR solve different problems.

Again, the code is self explanatory...

the `__STDC_VERSION__ >= 201112L` was true, but I run OSX so I wanted to execute the second branch of this if statement.

write me if you have any questions, but I won't check my messages until next monday!

have a good weekend,

François
